### PR TITLE
watch files creation and deletion

### DIFF
--- a/src/main/java/ru/qatools/beanloader/internal/FileWatcher.java
+++ b/src/main/java/ru/qatools/beanloader/internal/FileWatcher.java
@@ -12,6 +12,8 @@ import java.nio.file.WatchEvent;
 import java.nio.file.WatchKey;
 import java.nio.file.WatchService;
 
+import static java.nio.file.StandardWatchEventKinds.ENTRY_CREATE;
+import static java.nio.file.StandardWatchEventKinds.ENTRY_DELETE;
 import static java.nio.file.StandardWatchEventKinds.ENTRY_MODIFY;
 
 /**
@@ -36,7 +38,7 @@ public class FileWatcher implements Runnable {
     public void run() {
         FileSystem fileSystem = FileSystems.getDefault();
         try (WatchService service = fileSystem.newWatchService()) {
-            directoryPath.register(service, ENTRY_MODIFY);
+            directoryPath.register(service, ENTRY_CREATE, ENTRY_DELETE, ENTRY_MODIFY);
             watch(service, fileSystem.getPathMatcher(pathMatcherPattern));
         } catch (IOException e) {
             logger.error("Can't create watch service for directory {}", directoryPath, e);

--- a/src/test/java/ru/qatools/beanloader/FileWatcherTest.java
+++ b/src/test/java/ru/qatools/beanloader/FileWatcherTest.java
@@ -52,11 +52,15 @@ public class FileWatcherTest extends BeanChangingTest {
     }
 
     @Test
-    public void testListenerInvocationOnNewFileCreation() throws Exception {
+    public void testListenerInvocationOnNewFileCreationAndDeletion() throws Exception {
         String newXmlFileName = "another-bean.xml";
         File newFile = new File(RESOURCES_DIR + newXmlFileName);
         newFile.deleteOnExit();
-        setActualValue("some new value", newFile);
+        assertTrue(newFile.createNewFile());
+        assertThat(listener, should(beCalledWith(newFile.getPath()))
+                .whileWaitingUntil(timeoutHasExpired(60000)));
+        listener.reset();
+        assertTrue(newFile.delete());
         assertThat(listener, should(beCalledWith(newFile.getPath()))
                 .whileWaitingUntil(timeoutHasExpired(60000)));
     }


### PR DESCRIPTION
Register `WatchService` for `ENTRY_CREATE, ENTRY_DELETE, ENTRY_MODIFY` events, instead of `ENTRY_MODIFY` only.
